### PR TITLE
fix(security): validate localStorage game won status against actual guesses

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,26 +67,31 @@ export default function Home() {
   }
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      const savedDate = localStorage.getItem("brawldle-date");
-      const currentDate = getCurrentDate();
+    if (typeof window === "undefined") return;
+      
+    const savedDate = localStorage.getItem("brawldle-date");
+    const currentDate = getCurrentDate();
 
-      if (savedDate === currentDate) {
-        const savedGuesses = localStorage.getItem("brawldle-guesses");
-        const savedGameWon = localStorage.getItem("brawldle-won");
+    if (savedDate !== currentDate) {
+      localStorage.setItem("brawldle-date", currentDate);
+      localStorage.removeItem("brawldle-guesses");
+      localStorage.removeItem("brawldle-won");
+      return;
+    }
 
-        if (savedGuesses) {
-          setGuesses(JSON.parse(savedGuesses));
-        }
+    const savedGuesses = localStorage.getItem("brawldle-guesses");
+    const savedGameWon = localStorage.getItem("brawldle-won");
 
-        if (savedGameWon === "true") {
-          setGameWon(true);
-        }
-      } else {
-        localStorage.setItem("brawldle-date", currentDate);
-        localStorage.removeItem("brawldle-guesses");
-        localStorage.removeItem("brawldle-won");
-      }
+    if (savedGuesses) {
+      setGuesses(JSON.parse(savedGuesses));
+    }
+
+    if (savedGameWon === "true" && savedGuesses) {
+      const guesses: GuessResult[] = JSON.parse(savedGuesses) as GuessResult[];
+      const hasWon = guesses.some(
+        (guess) => guess.brawler.name === targetBrawler.name
+      );
+      setGameWon(hasWon);
     }
   }, []);
 


### PR DESCRIPTION
## Descrição

Este PR resolve a issue de segurança #1 onde usuários podem manipular o localStorage para falsificar vitórias no jogo diário.

## Problema

Usuários conseguiam:
1. Fazer uma tentativa qualquer no jogo
2. Abrir as ferramentas de desenvolvedor
3. Modificar os valores no localStorage para `true`
4. Obter uma vitória falsa sem acertar o brawler correto

## Solução Implementada

Adicionada validação que verifica se o status de vitória salvo no localStorage corresponde a uma tentativa válida que realmente acertou o brawler do dia:

- Quando carregar o estado salvo, verifica se existe uma tentativa (guess) que corresponde ao brawler alvo
- Só marca como vitória se existir uma tentativa válida que acerte o nome do brawler correto
- Mantém compatibilidade com dados salvos existentes
- Preserva funcionalidade offline

## Mudanças

- **Validação de integridade**: Verifica se `gameWon=true` corresponde a uma tentativa vencedora real
- **Prevenção de manipulação**: Impede vitórias falsas através de modificação do localStorage
- **Compatibilidade**: Não quebra saves existentes de usuários

## Limitações Conhecidas

- Usuários determinados ainda podem tentar outras formas de manipulação
- Esta solução foca na correção mais simples e efetiva
- Reduz significativamente os casos de trapaça casual

## Teste

Para testar a correção:
1. Fazer uma tentativa incorreta
2. Modificar localStorage `brawldle-won` para `"true"`
3. Recarregar a página
4. Verificar que o jogo não considera como vitória

Closes #1